### PR TITLE
Break infinite loops

### DIFF
--- a/lib/draftsman/draft.rb
+++ b/lib/draftsman/draft.rb
@@ -165,6 +165,9 @@ class Draftsman::Draft < ActiveRecord::Base
     ActiveRecord::Base.transaction do
       case self.event
       when 'create', 'update'
+        # Destroy draft
+        self.destroy
+
         # Parents must be published too
         self.draft_publication_dependencies.each { |dependency| dependency.publish! }
 
@@ -192,8 +195,6 @@ class Draftsman::Draft < ActiveRecord::Base
         
         self.item.reload
 
-        # Destroy draft
-        self.destroy
       when 'destroy'
         self.item.destroy
       end

--- a/lib/draftsman/version.rb
+++ b/lib/draftsman/version.rb
@@ -1,3 +1,3 @@
 module Draftsman
-  VERSION = '0.3.7'
+  VERSION = '0.3.7.1'
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -13,9 +13,6 @@
 
 ActiveRecord::Schema.define(version: 20150408234937) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
   create_table "bastards", force: :cascade do |t|
     t.string   "name"
     t.integer  "parent_id"
@@ -85,16 +82,6 @@ ActiveRecord::Schema.define(version: 20150408234937) do
     t.datetime "updated_at"
   end
 
-  create_table "trashables", force: :cascade do |t|
-    t.string   "name"
-    t.string   "title"
-    t.integer  "draft_id"
-    t.datetime "published_at"
-    t.datetime "trashed_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "talkatives", force: :cascade do |t|
     t.string   "before_comment"
     t.string   "around_early_comment"
@@ -103,6 +90,16 @@ ActiveRecord::Schema.define(version: 20150408234937) do
     t.integer  "draft_id"
     t.datetime "trashed_at"
     t.datetime "published_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "trashables", force: :cascade do |t|
+    t.string   "name"
+    t.string   "title"
+    t.integer  "draft_id"
+    t.datetime "published_at"
+    t.datetime "trashed_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -124,11 +121,4 @@ ActiveRecord::Schema.define(version: 20150408234937) do
     t.datetime "updated_at"
   end
 
-  add_foreign_key "children", "drafts"
-  add_foreign_key "only_children", "drafts"
-  add_foreign_key "parents", "drafts"
-  add_foreign_key "skippers", "drafts"
-  add_foreign_key "trashables", "drafts"
-  add_foreign_key "vanillas", "drafts"
-  add_foreign_key "whitelisters", "drafts"
 end


### PR DESCRIPTION
This change removes the draft at the beginning of the create/update block. Removing the draft early prevents infinite loops in the case where a parent object refers back to the object being published. Since the reference to the destroyed object can be used until it passes out of scope, no other code needs to change.
