### PR TITLE
allow to ignore reload

### DIFF
--- a/lib/draftsman/draft.rb
+++ b/lib/draftsman/draft.rb
@@ -189,7 +189,7 @@ class Draftsman::Draft < ActiveRecord::Base
           self.item.send("#{key}=", value)
         end
         self.item.save(:validate => false)
-        
+
         self.item.reload
 
         # Destroy draft
@@ -205,7 +205,7 @@ class Draftsman::Draft < ActiveRecord::Base
   # Example usage:
   #
   #     `@category = @category.reify if @category.draft?`
-  def reify
+  def reify(ignore_reload=false)
     without_identity_map do
       if !self.previous_draft.nil?
         reify_previous_draft.reify
@@ -215,7 +215,7 @@ class Draftsman::Draft < ActiveRecord::Base
           require self.item_type.underscore
         end
 
-        model = item.reload
+        model = item.reload unless ignore_reload
 
         attrs = self.class.object_col_is_json? ? self.object : Draftsman.serializer.load(object)
         model.class.unserialize_attributes_for_draftsman attrs
@@ -264,7 +264,7 @@ class Draftsman::Draft < ActiveRecord::Base
           self.item.class.where(:id => self.item).update_all "#{self.item.class.draft_association_name}_id".to_sym => nil,
                                                              self.item.class.trashed_at_attribute_name => nil
         end
-        
+
         self.destroy
       end
     end


### PR DESCRIPTION
The purpose of this PR is to tell draftsman that it doesn't have to reload the data. Sometimes, we are just performing GET requests to simply get data from the draft DB and then just return it to the client. If we use `includes(:item)` in our draftsman query, it will reload the item even though we've already gotten it with the includes. This will fix that.